### PR TITLE
Tracks with empty url removing

### DIFF
--- a/Meridian/Services/DataService.cs
+++ b/Meridian/Services/DataService.cs
@@ -87,7 +87,9 @@ namespace Meridian.Services
                 var response = await _vkontakte.Audio.Get(ownerId, albumId, count, offset);
                 if (response.Items != null)
                 {
-                    return new ItemsResponse<VkAudio>(response.Items.Select(i => i.ToAudio()).ToList(), response.TotalCount);
+                    var validTracks = RemoveCorruptedTracks(response.Items.Select(i => i.ToAudio()));
+
+                    return new ItemsResponse<VkAudio>(validTracks.ToList(), response.TotalCount);
                 }
             }
             catch (VkInvalidTokenException)
@@ -985,6 +987,11 @@ namespace Meridian.Services
 
                 NotificationService.NotifyProgressFinished(MainResources.NotificationSaved);
             }
+        }
+
+        private static IEnumerable<VkAudio> RemoveCorruptedTracks(IEnumerable<VkAudio> source)
+        {
+            return source.Where(x => x.Source != string.Empty);
         }
     }
 }


### PR DESCRIPTION
This fix prevents app crash while trying to play track with empty url. Such tracks don't be displayed on the vk.com website, so I made the same for the desktop app.